### PR TITLE
fix: left-align queue items and prevent last item clipping

### DIFF
--- a/apps/web/src/components/queue-panel.tsx
+++ b/apps/web/src/components/queue-panel.tsx
@@ -177,7 +177,7 @@ function QueueList({
 				Next up
 			</p>
 
-			<ScrollArea className="h-full pb-3">
+			<ScrollArea className="flex-1 min-h-0">
 				{upcoming.length === 0 ? (
 					<div className="flex flex-col items-center justify-center py-6 gap-2">
 						<ListX className="w-7 h-7 text-muted-foreground/30" strokeWidth={1.5} />
@@ -186,7 +186,7 @@ function QueueList({
 				) : (
 					<DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
 						<SortableContext items={upcoming.map((t) => t.id)} strategy={verticalListSortingStrategy}>
-							<div className="px-2 pb-2">
+							<div className="px-2 pb-4">
 								{upcoming.map((track) => (
 									<SortableTrackItem key={track.id} track={track} skipTo={skipTo} remove={remove} />
 								))}
@@ -235,14 +235,14 @@ function SortableTrackItem({
 			<button
 				type="button"
 				onClick={() => skipTo(track.id)}
-				className="flex items-center gap-3 min-w-0 flex-1"
+				className="flex items-center gap-3 min-w-0 flex-1 text-left"
 			>
 				<img
 					src={track.album.image}
 					alt={track.album.name}
 					className="w-9 h-9 rounded-md object-cover flex-shrink-0"
 				/>
-				<div className="min-w-0">
+				<div className="min-w-0 flex-1">
 					<p className="text-xs font-medium truncate group-hover:text-foreground transition-colors">
 						{track.name}
 					</p>


### PR DESCRIPTION
## Summary

Two small fixes to the now-playing queue panel:

- **Left-align title and artist.** The `<button>` wrapping the track info had no explicit `text-align`, so it inherited the user-agent default of `center` — which made shorter artist names appear centered under wider titles. Added `text-left` to the button and `flex-1` to the inner text column so truncation/alignment work on the full available width.
- **Prevent last queue item from being clipped.** The queue `ScrollArea` was using `h-full`, but its parent is a `flex flex-col` that also contains the "Next up" header. `h-full` resolved to 100% of the parent's height, ignoring the header, so the ScrollArea overflowed past the panel's visible bottom and the last few rows got cut off. Switched it to `flex-1 min-h-0` so it shares space with the header correctly, and bumped the inner content's `pb-2` → `pb-4` for a bit more breathing room.

## Test plan

- [ ] Open the queue panel with a long queue and scroll to the bottom — the last track should be fully visible
- [ ] Confirm the title and artist are flush-left under the album thumbnail for both short and long titles
- [ ] Verify drag-to-reorder and the hover X (remove) button still work
- [ ] Switch between Lyrics and Queue tabs to confirm the lyrics view still scrolls correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_011bG9unj7i44XgMC582apHv)_