### PR TITLE
fix: restore queue row truncation and X button visibility

### DIFF
--- a/apps/web/src/components/queue-panel.tsx
+++ b/apps/web/src/components/queue-panel.tsx
@@ -242,7 +242,7 @@ function SortableTrackItem({
 					alt={track.album.name}
 					className="w-9 h-9 rounded-md object-cover flex-shrink-0"
 				/>
-				<div className="min-w-0 flex-1">
+				<div className="min-w-0">
 					<p className="text-xs font-medium truncate group-hover:text-foreground transition-colors">
 						{track.name}
 					</p>


### PR DESCRIPTION
## Summary

Follow-up to #3 — that PR added `flex-1` to the queue row's inner text column to make the left-alignment fix visible. But Radix's `ScrollArea` wraps its viewport contents in a `display: table` div with `min-width: 100%`, which lets children exceed the panel width when they have intrinsic content that wants to grow. The `flex-1` text column broke the truncation chain, pushed long titles past the panel's right edge, and pushed the hover X (remove) button off-screen.

Dropping `flex-1` on the inner column restores truncation and brings the X button back. The `text-left` on the button (kept from #3) is on its own enough to left-align the artist beneath the title, because the `<p>` children fill the column and `text-align: left` is now inherited correctly.

## Test plan

- [ ] Hover any queue row — the X (remove) button should appear on the right
- [ ] Confirm long titles like "When You Gonna Learn? - Live at Leeds" truncate with an ellipsis instead of bleeding past the panel edge
- [ ] Confirm the artist name is still flush-left beneath the title (the original #3 fix)
- [ ] Drag-to-reorder still works


---
_Generated by [Claude Code](https://claude.ai/code/session_011bG9unj7i44XgMC582apHv)_