### PR TITLE
Fix albums with >50 tracks only loading 50

### DIFF
--- a/apps/api/src/lib/spotify-provider.ts
+++ b/apps/api/src/lib/spotify-provider.ts
@@ -125,6 +125,23 @@ export class SpotifyProvider implements MusicProvider {
 
 	async getAlbum(id: string): Promise<MusicAlbum> {
 		const album = await this.client.albums.get(id);
+
+		// The album endpoint only returns the first page of tracks (max 50).
+		// Walk `tracks.next` to collect the rest so albums with >50 tracks load fully.
+		let nextUrl: string | null | undefined = album.tracks.next;
+		while (nextUrl) {
+			const res = await fetch(nextUrl, {
+				headers: { Authorization: `Bearer ${this.token}` },
+			});
+			if (!res.ok) break;
+			const page = (await res.json()) as {
+				items: TrackSimplified[];
+				next: string | null;
+			};
+			album.tracks.items.push(...page.items);
+			nextUrl = page.next;
+		}
+
 		return mapAlbum(album);
 	}
 


### PR DESCRIPTION
The Spotify get-album endpoint returns a paginated tracks object capped
at 50 items. getAlbum mapped only that first page, so albums like
"80s 100 Hits" (100 songs) showed and replicated only 50 tracks.
Walk tracks.next to collect all pages before mapping, mirroring the
existing pagination in getArtist.

https://claude.ai/code/session_0124a9uHkb2eGPxTi36FGo2R